### PR TITLE
6: Rezerwacja miejsca i dodawanie na waitlistę

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1842,6 +1842,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -92,6 +92,7 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "serde",
  "sqlx",
  "tokio",
  "uuid",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -8,3 +8,5 @@ axum = "0.8"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "migrate", "uuid", "time"] }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
+serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 axum = "0.8"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "migrate", "uuid", "time"] }
 tokio = { version = "1", features = ["full"] }
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -9,4 +9,3 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres",
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 serde = { version = "1", features = ["derive"] }
-serde = { version = "1", features = ["derive"] }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
+ENV CARGO_INSTALL_ROOT=/usr/local
 RUN cargo install watchexec-cli
 
 COPY . .

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,10 +1,11 @@
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 
+mod routes;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let database_url =
-        std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
 
     let pool: PgPool = PgPoolOptions::new()
         .max_connections(5)
@@ -18,11 +19,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     sqlx::raw_sql(seed_sql).execute(&pool).await?;
     println!("Seed data loaded.");
 
-    let app = axum::Router::new().with_state(pool);
-
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
     println!("Listening on :3000");
-    axum::serve(listener, app).await?;
+    axum::serve(listener, routes::router(pool)).await?;
 
     Ok(())
 }

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -1,0 +1,10 @@
+use axum::{routing::post, Router};
+use sqlx::PgPool;
+
+mod reservations;
+
+pub fn router(pool: PgPool) -> Router {
+    Router::new()
+        .route("/events/{event_id}/reservations", post(reservations::reserve))
+        .with_state(pool)
+}

--- a/backend/src/routes/reservations.rs
+++ b/backend/src/routes/reservations.rs
@@ -1,0 +1,90 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Deserialize)]
+pub struct ReserveRequest {
+    user_id: Uuid,
+}
+
+#[derive(Serialize)]
+struct ReservationResponse {
+    reservation_id: Uuid,
+    seat_id: Uuid,
+}
+
+pub async fn reserve(
+    State(pool): State<PgPool>,
+    Path(event_id): Path<Uuid>,
+    Json(body): Json<ReserveRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let event_exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM events WHERE id = $1)")
+            .bind(event_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if !event_exists {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let seat_id: Option<Uuid> = sqlx::query_scalar(
+        "SELECT id FROM seats
+         WHERE event_id = $1 AND status = 'available'
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED",
+    )
+    .bind(event_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let seat_id = seat_id.ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    sqlx::query(
+        "UPDATE seats
+         SET status = 'held',
+             held_until = now() + interval '15 minutes',
+             held_by_user_id = $1
+         WHERE id = $2",
+    )
+    .bind(body.user_id)
+    .bind(seat_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let reservation_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO reservations (seat_id, user_id) VALUES ($1, $2) RETURNING id",
+    )
+    .bind(seat_id)
+    .bind(body.user_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    tx.commit()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ReservationResponse {
+            reservation_id,
+            seat_id,
+        }),
+    )
+        .into_response())
+}

--- a/backend/src/routes/reservations.rs
+++ b/backend/src/routes/reservations.rs
@@ -9,7 +9,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 #[derive(Deserialize)]
-pub struct ReserveRequest {
+struct ReserveRequest {
     user_id: Uuid,
 }
 

--- a/backend/src/routes/reservations.rs
+++ b/backend/src/routes/reservations.rs
@@ -19,6 +19,11 @@ struct ReservationResponse {
     seat_id: Uuid,
 }
 
+#[derive(Serialize)]
+struct WaitlistResponse {
+    waitlist_id: Uuid,
+}
+
 pub async fn reserve(
     State(pool): State<PgPool>,
     Path(event_id): Path<Uuid>,
@@ -51,40 +56,58 @@ pub async fn reserve(
     .await
     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let seat_id = seat_id.ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    match seat_id {
+        Some(seat_id) => {
+            sqlx::query(
+                "UPDATE seats
+                 SET status = 'held',
+                     held_until = now() + interval '15 minutes',
+                     held_by_user_id = $1
+                 WHERE id = $2",
+            )
+            .bind(body.user_id)
+            .bind(seat_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    sqlx::query(
-        "UPDATE seats
-         SET status = 'held',
-             held_until = now() + interval '15 minutes',
-             held_by_user_id = $1
-         WHERE id = $2",
-    )
-    .bind(body.user_id)
-    .bind(seat_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            let reservation_id: Uuid = sqlx::query_scalar(
+                "INSERT INTO reservations (seat_id, user_id) VALUES ($1, $2) RETURNING id",
+            )
+            .bind(seat_id)
+            .bind(body.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let reservation_id: Uuid = sqlx::query_scalar(
-        "INSERT INTO reservations (seat_id, user_id) VALUES ($1, $2) RETURNING id",
-    )
-    .bind(seat_id)
-    .bind(body.user_id)
-    .fetch_one(&mut *tx)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            tx.commit()
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    tx.commit()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            Ok((
+                StatusCode::CREATED,
+                Json(ReservationResponse {
+                    reservation_id,
+                    seat_id,
+                }),
+            )
+                .into_response())
+        }
+        None => {
+            let waitlist_id: Uuid = sqlx::query_scalar(
+                "INSERT INTO waitlist (event_id, user_id) VALUES ($1, $2) RETURNING id",
+            )
+            .bind(event_id)
+            .bind(body.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    Ok((
-        StatusCode::CREATED,
-        Json(ReservationResponse {
-            reservation_id,
-            seat_id,
-        }),
-    )
-        .into_response())
+            tx.commit()
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+            Ok((StatusCode::ACCEPTED, Json(WaitlistResponse { waitlist_id })).into_response())
+        }
+    }
 }

--- a/backend/src/routes/reservations.rs
+++ b/backend/src/routes/reservations.rs
@@ -9,7 +9,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 #[derive(Deserialize)]
-struct ReserveRequest {
+pub struct ReserveRequest {
     user_id: Uuid,
 }
 

--- a/compose.yml
+++ b/compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       DATABASE_URL: postgres://user:password@db:5432/tickets
     volumes:
-      - ./backend:/usr/src/app
+      - ./backend:/usr/src/app:z
       - backend_target:/usr/src/app/target
     ports:
       - "3000:3000"


### PR DESCRIPTION
Skutkiem tego PRa mozna uderzac POSTem o endpoint /events/:id/reservations, np. o event id a0000000-0000-0000-0000-000000000004 bo ma najmniej miejsc, i po dziesiatym uderzeniu zobaczyc, ze przestajemy dostawac idki miejsc, a idki miejsca na waitliscie.

Przyklad:
```bash
curl -s -X POST http://localhost:3000/events/a0000000-0000-0000-0000-000000000001/reservations \
        -H "Content-Type: application/json" \
        -d '{"user_id": "00000000-0000-0000-0000-000000000001"}'
```

Mozna oczywiscie rowniez ogladac bazke:
```
psql postgres://user:password@localhost:5432/tickets
```