### PR TITLE
18: Opłacanie rezerwacji

### DIFF
--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -9,5 +9,9 @@ pub fn router(pool: PgPool) -> Router {
             "/events/{event_id}/reservations",
             post(reservations::reserve),
         )
+        .route(
+            "/reservations/{reservation_id}/payment",
+            post(reservations::pay),
+        )
         .with_state(pool)
 }

--- a/backend/src/routes/reservations.rs
+++ b/backend/src/routes/reservations.rs
@@ -24,6 +24,17 @@ struct WaitlistResponse {
     waitlist_id: Uuid,
 }
 
+#[derive(Deserialize)]
+pub struct PaymentRequest {
+    user_id: Uuid,
+}
+
+#[derive(Serialize)]
+struct PaymentResponse {
+    reservation_id: Uuid,
+    seat_id: Uuid,
+}
+
 pub async fn reserve(
     State(pool): State<PgPool>,
     Path(event_id): Path<Uuid>,
@@ -110,4 +121,64 @@ pub async fn reserve(
             Ok((StatusCode::ACCEPTED, Json(WaitlistResponse { waitlist_id })).into_response())
         }
     }
+}
+
+pub async fn pay(
+    State(pool): State<PgPool>,
+    Path(reservation_id): Path<Uuid>,
+    Json(body): Json<PaymentRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let row: Option<(Uuid, String, Option<Uuid>, bool)> = sqlx::query_as(
+        "SELECT s.id, s.status, s.held_by_user_id, s.held_until < now() AS expired
+         FROM reservations r
+         JOIN seats s ON s.id = r.seat_id
+         WHERE r.id = $1
+         FOR UPDATE OF s",
+    )
+    .bind(reservation_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let Some((seat_id, status, held_by, expired)) = row else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    if status != "held" || held_by != Some(body.user_id) {
+        return Err(StatusCode::CONFLICT);
+    }
+
+    if expired {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    sqlx::query(
+        "UPDATE seats
+         SET status = 'sold',
+             held_until = NULL,
+             held_by_user_id = NULL
+         WHERE id = $1",
+    )
+    .bind(seat_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    tx.commit()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok((
+        StatusCode::OK,
+        Json(PaymentResponse {
+            reservation_id,
+            seat_id,
+        }),
+    )
+        .into_response())
 }

--- a/backend/src/routes/reservations.rs
+++ b/backend/src/routes/reservations.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
+use sqlx::types::time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Deserialize)]
@@ -128,19 +129,22 @@ pub async fn pay(
     Path(reservation_id): Path<Uuid>,
     Json(body): Json<PaymentRequest>,
 ) -> Result<impl IntoResponse, StatusCode> {
+    let received_at = OffsetDateTime::now_utc();
+
     let mut tx = pool
         .begin()
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let row: Option<(Uuid, String, Option<Uuid>, bool)> = sqlx::query_as(
-        "SELECT s.id, s.status, s.held_by_user_id, s.held_until < now() AS expired
+        "SELECT s.id, s.status, s.held_by_user_id, s.held_until < $2 AS expired
          FROM reservations r
          JOIN seats s ON s.id = r.seat_id
          WHERE r.id = $1
          FOR UPDATE OF s",
     )
     .bind(reservation_id)
+    .bind(received_at)
     .fetch_optional(&mut *tx)
     .await
     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;


### PR DESCRIPTION
Prosty "restowy" POST /reservations/:id/payment { user_id }. Jedyna ciekawosc tutaj jest z race conditionem, mozliwym w takiej sytuacji:

Czyjas rezerwacja teoretycznie dobiega konca, ale sweeper nie zdaza jej przedawnic. W tym krotkim (maks. 5-sekundowym) oknie ktos moze kliknac "zaplac". Chcemy wylapac ten przypadek: if (timestamp w ktorym odebralismy request jest pozniejszy od held_until) { return 403 }.