### PR TITLE
Skrócenie czasu rezerwacji do 30 sekund

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,6 +4,8 @@ use sqlx::postgres::PgPoolOptions;
 mod routes;
 mod tasks;
 
+pub const HOLD_DURATION_SECS: u64 = 30;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");

--- a/backend/src/routes/reservations.rs
+++ b/backend/src/routes/reservations.rs
@@ -61,7 +61,7 @@ pub async fn reserve(
             sqlx::query(
                 "UPDATE seats
                  SET status = 'held',
-                     held_until = now() + interval '15 minutes',
+                     held_until = now() + interval '30 seconds',
                      held_by_user_id = $1
                  WHERE id = $2",
             )

--- a/backend/src/routes/reservations.rs
+++ b/backend/src/routes/reservations.rs
@@ -4,9 +4,13 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;
+
+use crate::HOLD_DURATION_SECS;
 
 #[derive(Deserialize)]
 pub struct ReserveRequest {
@@ -61,10 +65,11 @@ pub async fn reserve(
             sqlx::query(
                 "UPDATE seats
                  SET status = 'held',
-                     held_until = now() + interval '30 seconds',
-                     held_by_user_id = $1
-                 WHERE id = $2",
+                     held_until = now() + $1,
+                     held_by_user_id = $2
+                 WHERE id = $3",
             )
+            .bind(Duration::from_secs(HOLD_DURATION_SECS))
             .bind(body.user_id)
             .bind(seat_id)
             .execute(&mut *tx)

--- a/backend/src/tasks/sweeper.rs
+++ b/backend/src/tasks/sweeper.rs
@@ -4,6 +4,8 @@ use sqlx::PgPool;
 use tokio::time::Instant;
 use uuid::Uuid;
 
+use crate::HOLD_DURATION_SECS;
+
 const SWEEP_INTERVAL: Duration = Duration::from_secs(5);
 
 pub async fn run(pool: PgPool) {
@@ -68,10 +70,11 @@ async fn sweep_one(pool: &PgPool) -> Result<bool, sqlx::Error> {
             sqlx::query(
                 "UPDATE seats
                  SET held_by_user_id = $1,
-                     held_until = now() + interval '30 seconds'
-                 WHERE id = $2",
+                     held_until = now() + $2
+                 WHERE id = $3",
             )
             .bind(user_id)
+            .bind(Duration::from_secs(HOLD_DURATION_SECS))
             .bind(seat_id)
             .execute(&mut *tx)
             .await?;

--- a/backend/src/tasks/sweeper.rs
+++ b/backend/src/tasks/sweeper.rs
@@ -68,7 +68,7 @@ async fn sweep_one(pool: &PgPool) -> Result<bool, sqlx::Error> {
             sqlx::query(
                 "UPDATE seats
                  SET held_by_user_id = $1,
-                     held_until = now() + interval '15 minutes'
+                     held_until = now() + interval '30 seconds'
                  WHERE id = $2",
             )
             .bind(user_id)


### PR DESCRIPTION
Wcale nie tak mniej realistyczne (dla eventow z duzym popytem wyobrazam sobie ze klienci nie powinni miec tak duzego okna na zaplate jak 15 minut), a znacznie mniej uciazliwe w przypadku testowania.